### PR TITLE
Fix FluentAvalonia#641: AppWindow is wrongly resized when changing Fullscreen to Normal mode

### DIFF
--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -93,7 +93,10 @@ public partial class AppWindow : Window
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        base.OnPropertyChanged(change);
+        if (!this.IsWindows || change.Property != WindowStateProperty)  // Lazy base call OnPropertyChanged
+        {
+            base.OnPropertyChanged(change);
+        }
 
         if (change.Property == IconProperty)
         {
@@ -111,6 +114,7 @@ public partial class AppWindow : Window
             {
                 HandleFullScreenTransition(change.GetNewValue<WindowState>());
                 OnExtendsContentIntoTitleBarChanged(TitleBar.ExtendsContentIntoTitleBar);
+                base.OnPropertyChanged(change);  // Enable window size modifications before Avalonia's own logic
             }
 
             if (!_hasShown)
@@ -136,7 +140,7 @@ public partial class AppWindow : Window
                         _win32Manager.LastUserHeight = newV;
                     }
                 }
-            }            
+            }
         }
     }
 


### PR DESCRIPTION
Fix issue amwx/FluentAvalonia#641 by calling the base `OnPropertyChanged` after handling fullscreen changes, when `WindowStateProperty` is concerned on Windows.
I tested this fix using a simple app on Windows 11 24H2, but my tests are likely not exhaustive.