### PR TITLE
Change <Version> to <VersionPrefix> in FluentAvalonia.csproj

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.1.0</Version>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request includes a small change to the `src/Directory.Build.props` file. The change updates the versioning property from `Version` to `VersionPrefix`.

* [`src/Directory.Build.props`](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L7-R7): Updated the versioning property from `Version` to `VersionPrefix`, enabling custom version building at compile time.