### PR TITLE
Fix package ID in workflow nuget-publish.yml

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -2,12 +2,13 @@ name: Publish NuGet Package
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   workflow_dispatch:
 
 env:
   DOTNET_INSTALL_DIR: '~/.dotnet'
   MAIN_CSPROJ: './src/FluentAvalonia/FluentAvalonia.csproj'
+  NUGET_GPR_URL: "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
 jobs:
   build:
@@ -38,7 +39,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0'
-          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+          source-url: ${{ env.NUGET_GPR_URL }}
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -54,6 +55,7 @@ jobs:
       - name: Build project
         run: |
           dotnet build "${{ env.MAIN_CSPROJ }}" \
+            /p:NoWarn=CS1591 \
             --configuration Release \
             --no-restore
 
@@ -67,4 +69,8 @@ jobs:
             --output ./nupkgs
       
       - name: Publish NuGet package to GitHub Packages
-        run: dotnet nuget push ./nupkgs/*.nupkg
+        run: |
+          dotnet nuget push ./nupkgs/*.nupkg \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --source "${{ env.NUGET_GPR_URL }}" \
+            --timeout 60

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Pack project into NuGet package
         run: |
           dotnet pack "${{ env.MAIN_CSPROJ }}" \
-            /p:Name=Redcft.FluentAvalonia \
+            /p:PackageId=Redcft.FluentAvalonia \
             /p:VersionSuffix=${{ env.PACKAGE_VERSION_SUFFIX }} \
             --configuration Release \
             --no-build \


### PR DESCRIPTION
This pull request includes several changes to the `nuget-publish.yml` workflow file to improve the NuGet package publishing process. The most important changes include updating the branch name, using an environment variable for the NuGet source URL, adding a build warning suppression, and modifying the package ID and publishing command.

Changes in workflow configuration:

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L5-R11): Updated the branch name from `main` to `master`.

Environment variable usage:

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L41-R42): Introduced `NUGET_GPR_URL` environment variable and used it for the `source-url` in the `setup-dotnet` action.

Build and packaging improvements:

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R58-R76): Added `/p:NoWarn=CS1591` to the build command to suppress specific warnings.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R58-R76): Changed `/p:Name=Redcft.FluentAvalonia` to `/p:PackageId=Redcft.FluentAvalonia` in the pack command.

Publishing enhancements:

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R58-R76): Updated the `dotnet nuget push` command to include `--api-key`, `--source`, and `--timeout` options for better control over the publishing process.